### PR TITLE
feat: implemented way to check if a player is online

### DIFF
--- a/Tibia More/Features/Characters/CharactersListRowView.swift
+++ b/Tibia More/Features/Characters/CharactersListRowView.swift
@@ -10,10 +10,15 @@ import SwiftUI
 struct CharactersListRowView: View {
     
     var model: CharacterInfoModel
+    var isOnline: Bool = false
     
     var body: some View {
         VStack(alignment: .leading) {
             HStack {
+                Circle()
+                    .fill(isOnline ? .green : .red)
+                    .frame(width: 10)
+                
                 Text(model.name ?? "")
                     .font(.title)
                 

--- a/Tibia More/Features/Characters/CharactersListView.swift
+++ b/Tibia More/Features/Characters/CharactersListView.swift
@@ -15,7 +15,7 @@ struct CharactersListView: View {
     var body: some View {
         NavigationStack(path: $viewModel.navigationPath) {
             List(viewModel.characters, id: \.self) { character in
-                CharactersListRowView(model: character.character)
+                CharactersListRowView(model: character.character, isOnline: character.isOnline ?? false)
                     .contentShape(Rectangle())
                     .onTapGesture {
                         viewModel.navigationPath.append(NavigationRoutes.Characters.details(with: character))

--- a/Tibia More/Features/Characters/CharactersListViewModel.swift
+++ b/Tibia More/Features/Characters/CharactersListViewModel.swift
@@ -37,6 +37,8 @@ final class CharactersListViewModel {
         
         for character in characters {
             await fetch(name: character)
+            let players = await playersOnlineFrom(world: self.characters.last?.character.world ?? "")
+            self.characters[self.characters.count - 1].isOnline = players.contains(where: { $0.name == character })
         }
         
         self.isLoading = false
@@ -48,6 +50,16 @@ final class CharactersListViewModel {
             characters.append(model)
         } catch {
             print("Some error: \(error)")
+        }
+    }
+    
+    private func playersOnlineFrom(world name: String) async -> [OnlinePlayersModel] {
+        do {
+            let model = try await WorldsService.shared.fetch(world: name)
+            return model.onlinePlayers
+        } catch {
+            print("Some world error: \(error)")
+            return []
         }
     }
     

--- a/Tibia More/Features/Characters/Details/CharacterSearchDetailsView.swift
+++ b/Tibia More/Features/Characters/Details/CharacterSearchDetailsView.swift
@@ -66,6 +66,7 @@ struct CharacterSearchDetailsView: View {
             }
             
             CharacterSearchDetailsViewRow(title: "Title", value: viewModel.model.character.title ?? "None")
+            CharacterSearchDetailsViewRow(title: "Status", value: viewModel.model.isOnline ?? false ? "Online" : "Offline")
             CharacterSearchDetailsViewRow(title: "Unlocked Titles", value: String(viewModel.model.character.unlockedTitles ?? 0))
             CharacterSearchDetailsViewRow(title: "Sex", value: viewModel.model.character.sex ?? "No sex found")
             CharacterSearchDetailsViewRow(title: "Vocation", value: viewModel.model.character.vocation ?? "No vocation found")
@@ -249,5 +250,6 @@ extension CharacterSearchDetailsView {
                                                                                                            position: nil,
                                                                                                            status: "offline",
                                                                                                            traded: nil,
-                                                                                                           world: "Quelibra")])))
+                                                                                                           world: "Quelibra")], 
+                                                               isOnline: false)))
 }

--- a/Tibia More/Features/Characters/Search/CharactersSearchView.swift
+++ b/Tibia More/Features/Characters/Search/CharactersSearchView.swift
@@ -60,6 +60,8 @@ extension CharactersSearchView {
     
     private func routeToDetails() async {
         await viewModel.fetch()
+        let players = await viewModel.playersOnlineFrom(world: viewModel.model?.character.world ?? "")
+        viewModel.model?.isOnline = players.contains(where: { $0.name == viewModel.model?.character.name ?? "" })
         
         if let model = viewModel.model {
             self.navigationPath.append(NavigationRoutes.Characters.detailsFromSearch(with: model))

--- a/Tibia More/Features/Characters/Search/CharactersSearchViewModel.swift
+++ b/Tibia More/Features/Characters/Search/CharactersSearchViewModel.swift
@@ -30,4 +30,14 @@ final class CharactersSearchViewModel {
             self.isLoading = false
         }
     }
+    
+    func playersOnlineFrom(world name: String) async -> [OnlinePlayersModel] {
+        do {
+            let model = try await WorldsService.shared.fetch(world: name)
+            return model.onlinePlayers
+        } catch {
+            print("Some world error: \(error)")
+            return []
+        }
+    }
 }

--- a/Tibia More/Networking/Characters/Models/CharactersModel.swift
+++ b/Tibia More/Networking/Characters/Models/CharactersModel.swift
@@ -16,6 +16,7 @@ struct CharacterModel: Decodable, Hashable, Equatable {
     let accountInformation: AccountInformationModel?
     let achievements: [AchievementsModel]?
     let otherCharacters: [OtherCharactersModel]?
+    var isOnline: Bool?
 }
 
 // MARK: - Characters Info


### PR DESCRIPTION
When we retrieve some player data, we also check the worlds api to see if the player is online at the moment. May have some delays for the world API to update the list of online players.

Now we have the little circle green or red to indicate the player status:

<img src="https://github.com/adolphopiazza/tibiamore-ios/assets/13540565/63128728-bcb1-4e1c-a69c-9c2834d54c26" width=320 height=700>

And also we have the "Status" row at the player details:

<img src="https://github.com/adolphopiazza/tibiamore-ios/assets/13540565/d9e4b60e-f622-4f43-86b3-d8593ffbb4c1" width=320 height=700>