### PR TITLE
feat: implemented highscores view

### DIFF
--- a/Tibia More.xcodeproj/project.pbxproj
+++ b/Tibia More.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		387E5A0A2B5B4C35009CA577 /* BoostableBossesModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 387E5A092B5B4C35009CA577 /* BoostableBossesModel.swift */; };
 		387E5A0C2B5C0CE5009CA577 /* HighscoresModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 387E5A0B2B5C0CE5009CA577 /* HighscoresModel.swift */; };
 		387E5A0F2B5C133D009CA577 /* HighscoresView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 387E5A0E2B5C133D009CA577 /* HighscoresView.swift */; };
+		387E5A112B5C4BBF009CA577 /* HighscoresViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 387E5A102B5C4BBF009CA577 /* HighscoresViewModel.swift */; };
 		38A28A822B27C2D800C707F7 /* NetworkErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38A28A812B27C2D800C707F7 /* NetworkErrors.swift */; };
 		38A28AA52B2B75E300C707F7 /* Strings+Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38A28AA42B2B75E300C707F7 /* Strings+Ext.swift */; };
 		38A28AA72B2B7AED00C707F7 /* SafariView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38A28AA62B2B7AED00C707F7 /* SafariView.swift */; };
@@ -137,6 +138,7 @@
 		387E5A092B5B4C35009CA577 /* BoostableBossesModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoostableBossesModel.swift; sourceTree = "<group>"; };
 		387E5A0B2B5C0CE5009CA577 /* HighscoresModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighscoresModel.swift; sourceTree = "<group>"; };
 		387E5A0E2B5C133D009CA577 /* HighscoresView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighscoresView.swift; sourceTree = "<group>"; };
+		387E5A102B5C4BBF009CA577 /* HighscoresViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighscoresViewModel.swift; sourceTree = "<group>"; };
 		38A28A812B27C2D800C707F7 /* NetworkErrors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkErrors.swift; sourceTree = "<group>"; };
 		38A28AA42B2B75E300C707F7 /* Strings+Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Strings+Ext.swift"; sourceTree = "<group>"; };
 		38A28AA62B2B7AED00C707F7 /* SafariView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariView.swift; sourceTree = "<group>"; };
@@ -418,6 +420,7 @@
 			isa = PBXGroup;
 			children = (
 				387E5A0E2B5C133D009CA577 /* HighscoresView.swift */,
+				387E5A102B5C4BBF009CA577 /* HighscoresViewModel.swift */,
 			);
 			path = Highscores;
 			sourceTree = "<group>";
@@ -693,6 +696,7 @@
 				3823D5EB2B5227B0000677CB /* WorldsDetailsViewRow.swift in Sources */,
 				3838176B2B49A660000E13D7 /* WorldsListViewModel.swift in Sources */,
 				3872B0302B56099F00725178 /* CreaturesDetailViewModel.swift in Sources */,
+				387E5A112B5C4BBF009CA577 /* HighscoresViewModel.swift in Sources */,
 				38B1E47A2B499C8900A18AB5 /* WorldsModel.swift in Sources */,
 				387E5A0C2B5C0CE5009CA577 /* HighscoresModel.swift in Sources */,
 				38D6708F2B52E8840043A093 /* UtilsListView.swift in Sources */,

--- a/Tibia More/Features/Utils/Highscores/HighscoresView.swift
+++ b/Tibia More/Features/Utils/Highscores/HighscoresView.swift
@@ -9,20 +9,89 @@ import SwiftUI
 
 struct HighscoresView: View {
     
+    @State private var viewModel = HighscoresViewModel()
+    
     var body: some View {
-        Text("Hello, Highscores")
-            .task {
-                do {
-                    let result = try await UtilsService.shared.fetchHighscores(vocation: .druids)
-                    print(result)
-                } catch {
-                    print(error)
+        Form {
+            Section("Filters") {
+                filtersView
+            }
+            
+            Section("Highscores") {
+                List(Array(viewModel.highscores.enumerated()), id: \.offset) { (index, player) in
+                    VStack(alignment: .leading) {
+                        Text("\(index + 1). \(player.name)")
+                            .font(.title)
+                        
+                        LabeledContent("Level", value: String(player.level))
+                        LabeledContent("Vocation", value: player.vocation)
+                        LabeledContent("World", value: player.world)
+                        LabeledContent(viewModel.selectedCategory.title, value: String(player.value))
+                            .font(.headline)
+                    }
                 }
             }
+        }
+        .opacity(viewModel.hasError || viewModel.isLoading ? 0 : 1)
+        .fontDesign(.serif)
+        .navigationTitle(viewModel.viewTitle)
+        // yeah these onChanges are ugly as hell =[
+        // maybe refactor to use combine (with subscribers?)
+        .onChange(of: viewModel.selectedWorld, { _, _ in
+            Task {
+                await viewModel.fetchHighscores()
+            }
+        })
+        .onChange(of: viewModel.selectedCategory, { _, _ in
+            Task {
+                await viewModel.fetchHighscores()
+            }
+        })
+        .onChange(of: viewModel.selectedVocation, { _, _ in
+            Task {
+                await viewModel.fetchHighscores()
+            }
+        })
+        .overlay {
+            if viewModel.isLoading {
+                ProgressView()
+            }
+            
+            if viewModel.hasError && !viewModel.isLoading {
+                ContentUnavailableView("Sorry, we got an error",
+                                       systemImage: .SFImages.networkSlash)
+            }
+        }
     }
     
+    private var filtersView: some View {
+        Group {
+            Picker("World", selection: $viewModel.selectedWorld) {
+                ForEach(viewModel.worlds, id: \.self) { world in
+                    Text(world)
+                }
+            }
+            .pickerStyle(.navigationLink)
+            
+            Picker("Category", selection: $viewModel.selectedCategory) {
+                ForEach(viewModel.categories, id: \.self) { category in
+                    Text(category.title)
+                }
+            }
+            .pickerStyle(.navigationLink)
+            
+            Picker("Vocation", selection: $viewModel.selectedVocation) {
+                ForEach(viewModel.vocations, id: \.self) { vocation in
+                    Text(vocation.title)
+                }
+            }
+            .pickerStyle(.menu)
+        }
+    }
 }
 
 #Preview {
-    HighscoresView()
+    NavigationStack {
+        HighscoresView()
+    }
 }

--- a/Tibia More/Features/Utils/Highscores/HighscoresViewModel.swift
+++ b/Tibia More/Features/Utils/Highscores/HighscoresViewModel.swift
@@ -1,0 +1,76 @@
+//
+//  HighscoresViewModel.swift
+//  Tibia More
+//
+//  Created by Adolpho Francisco Zimmermann Piazza on 20/01/24.
+//
+
+import Foundation
+
+@Observable
+final class HighscoresViewModel {
+    
+    let viewTitle: String = "Highscores"
+    var isLoading: Bool = false
+    var hasError: Bool = false
+    
+    var worlds: [String] = ["All"]
+    var selectedWorld: String = "All"
+    
+    var categories: [HighscoresCategories] = HighscoresCategories.allCases
+    var selectedCategory: HighscoresCategories = .experience
+    
+    var vocations: [HighscoresVocations] = HighscoresVocations.allCases
+    var selectedVocation: HighscoresVocations = .all
+    
+    var highscores: [HighscoresPlayersModel] = []
+    
+    init() {
+        Task {
+            await self.fetchWorlds()
+            await self.fetchHighscores()
+        }
+    }
+    
+    @MainActor func fetchWorlds() async {
+        defer {
+            self.isLoading = false
+        }
+        
+        self.isLoading = true
+        
+        do {
+            let result = try await WorldsService.shared.fetch()
+            
+            for world in result.regularWorlds {
+                self.worlds.append(world.name)
+            }
+            
+            self.hasError = false
+        } catch {
+            print("Some error on fetching worlds on HighscoresViewModel: \(error)")
+            self.hasError = true
+        }
+    }
+    
+    @MainActor func fetchHighscores() async {
+        defer {
+            self.isLoading = false
+        }
+        
+        self.isLoading = true
+        self.highscores.removeAll()
+        
+        do {
+            let result = try await UtilsService.shared.fetchHighscores(world: self.selectedWorld,
+                                                                       category: self.selectedCategory,
+                                                                       vocation: self.selectedVocation)
+            self.highscores = result.highscoreList
+            self.hasError = false
+        } catch {
+            print("Some error fetching highscores on HighscoresViewModel: \(error)")
+            self.hasError = true
+        }
+    }
+    
+}

--- a/Tibia More/Features/Utils/UtilsListView.swift
+++ b/Tibia More/Features/Utils/UtilsListView.swift
@@ -35,7 +35,7 @@ struct UtilsListView: View {
                     case .boostedCreature:
                         BoostedCreatureView()
                     case .highscores:
-                        Text("Highscores")
+                        HighscoresView()
                     case .killStatistics:
                         Text("Kill Statistics")
                     case .fansites:

--- a/Tibia More/Networking/Utils/Models/HighscoresModel.swift
+++ b/Tibia More/Networking/Utils/Models/HighscoresModel.swift
@@ -24,9 +24,10 @@ struct HighscoresPlayersModel: Decodable {
     let vocation: String
     let world: String
     let level: Int
+    let value: Int
 }
 
-enum HighscoresVocations: String, Decodable {
+enum HighscoresVocations: String, Decodable, CaseIterable {
     case all
     case knights
     case druids
@@ -44,12 +45,12 @@ enum HighscoresVocations: String, Decodable {
         case .sorcerers:
             return "Sorcerers"
         case .paladins:
-            return "Paladinds"
+            return "Paladins"
         }
     }
 }
 
-enum HighscoresCategories: String, Decodable {
+enum HighscoresCategories: String, Decodable, CaseIterable {
     case achievements
     case axefighting
     case charmpoints


### PR DESCRIPTION
The Highscores view was implemented:

<img src="https://github.com/adolphopiazza/tibiamore-ios/assets/13540565/1f71f209-5a3b-42f7-98dd-4f43474efbef" width=320 height=700>

You can set the filters: World, Category and Vocation. The world filters gets filled on the init() and calls the worlds endpoint.