### PR TITLE
feat: implemented kill statistics view

### DIFF
--- a/Tibia More.xcodeproj/project.pbxproj
+++ b/Tibia More.xcodeproj/project.pbxproj
@@ -20,6 +20,8 @@
 		38084D592B543F04003FCD1B /* CreaturesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38084D582B543F04003FCD1B /* CreaturesViewModel.swift */; };
 		3808B1ED2B5C688A003E4AB8 /* KillStatisticsModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3808B1EC2B5C688A003E4AB8 /* KillStatisticsModel.swift */; };
 		3808B1F02B5C6A55003E4AB8 /* KillStatisticsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3808B1EF2B5C6A55003E4AB8 /* KillStatisticsView.swift */; };
+		3808B1F22B5C6B94003E4AB8 /* KillStatisticsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3808B1F12B5C6B94003E4AB8 /* KillStatisticsViewModel.swift */; };
+		3808B1F42B5C845C003E4AB8 /* KillStatisticsTotalsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3808B1F32B5C845C003E4AB8 /* KillStatisticsTotalsView.swift */; };
 		3823D5EB2B5227B0000677CB /* WorldsDetailsViewRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3823D5EA2B5227B0000677CB /* WorldsDetailsViewRow.swift */; };
 		382A29C22B1EA97500961FE2 /* Tibia_MoreApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 382A29C12B1EA97500961FE2 /* Tibia_MoreApp.swift */; };
 		382A29C42B1EA97500961FE2 /* TabBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 382A29C32B1EA97500961FE2 /* TabBarView.swift */; };
@@ -109,6 +111,8 @@
 		38084D582B543F04003FCD1B /* CreaturesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreaturesViewModel.swift; sourceTree = "<group>"; };
 		3808B1EC2B5C688A003E4AB8 /* KillStatisticsModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KillStatisticsModel.swift; sourceTree = "<group>"; };
 		3808B1EF2B5C6A55003E4AB8 /* KillStatisticsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KillStatisticsView.swift; sourceTree = "<group>"; };
+		3808B1F12B5C6B94003E4AB8 /* KillStatisticsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KillStatisticsViewModel.swift; sourceTree = "<group>"; };
+		3808B1F32B5C845C003E4AB8 /* KillStatisticsTotalsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KillStatisticsTotalsView.swift; sourceTree = "<group>"; };
 		3823D5EA2B5227B0000677CB /* WorldsDetailsViewRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldsDetailsViewRow.swift; sourceTree = "<group>"; };
 		382A29BE2B1EA97500961FE2 /* Tibia More.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Tibia More.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		382A29C12B1EA97500961FE2 /* Tibia_MoreApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tibia_MoreApp.swift; sourceTree = "<group>"; };
@@ -239,6 +243,8 @@
 			isa = PBXGroup;
 			children = (
 				3808B1EF2B5C6A55003E4AB8 /* KillStatisticsView.swift */,
+				3808B1F12B5C6B94003E4AB8 /* KillStatisticsViewModel.swift */,
+				3808B1F32B5C845C003E4AB8 /* KillStatisticsTotalsView.swift */,
 			);
 			path = KillStatistics;
 			sourceTree = "<group>";
@@ -749,10 +755,12 @@
 				38C09ADF2B48A86B006B6B34 /* CharacterSearchDetailsViewModel.swift in Sources */,
 				38A3EDFD2B2F3DE1003C7BDA /* CharacterSearchDetailsView.swift in Sources */,
 				382A29FC2B1EAF1100961FE2 /* TabBarItem.swift in Sources */,
+				3808B1F42B5C845C003E4AB8 /* KillStatisticsTotalsView.swift in Sources */,
 				3800FC702B34DC8B00685C5E /* CharacterSearchDetailsViewRow.swift in Sources */,
 				387E5A032B5B42F4009CA577 /* CreaturesDetailAboutView.swift in Sources */,
 				38AC7CEC2B24BD7900B6DF29 /* NewsListRowViewModel.swift in Sources */,
 				3808B1ED2B5C688A003E4AB8 /* KillStatisticsModel.swift in Sources */,
+				3808B1F22B5C6B94003E4AB8 /* KillStatisticsViewModel.swift in Sources */,
 				382A29C22B1EA97500961FE2 /* Tibia_MoreApp.swift in Sources */,
 				3800FC722B35D90700685C5E /* CharacterSearchDetailsAchievementView.swift in Sources */,
 				38AC7CF12B253FEE00B6DF29 /* NewsListDetailViewModel.swift in Sources */,

--- a/Tibia More/Features/Utils/BoostedBoss/BoostedBossViewModel.swift
+++ b/Tibia More/Features/Utils/BoostedBoss/BoostedBossViewModel.swift
@@ -37,7 +37,7 @@ final class BoostedBossViewModel {
         }
     }
     
-    @MainActor func fetch() async {
+    @MainActor private func fetch() async {
         defer {
             self.isLoading = false
         }

--- a/Tibia More/Features/Utils/BoostedCreature/BoostedCreatureViewModel.swift
+++ b/Tibia More/Features/Utils/BoostedCreature/BoostedCreatureViewModel.swift
@@ -39,7 +39,7 @@ final class BoostedCreatureViewModel {
         }
     }
     
-    @MainActor func fetch() async -> String? {
+    @MainActor private func fetch() async -> String? {
         defer {
             self.isLoading = false
         }
@@ -57,7 +57,7 @@ final class BoostedCreatureViewModel {
         }
     }
     
-    @MainActor func fetchDetails(of race: String) async {
+    @MainActor private func fetchDetails(of race: String) async {
         defer {
             self.isLoading = false
         }

--- a/Tibia More/Features/Utils/Highscores/HighscoresViewModel.swift
+++ b/Tibia More/Features/Utils/Highscores/HighscoresViewModel.swift
@@ -32,7 +32,7 @@ final class HighscoresViewModel {
         }
     }
     
-    @MainActor func fetchWorlds() async {
+    @MainActor private func fetchWorlds() async {
         defer {
             self.isLoading = false
         }

--- a/Tibia More/Features/Utils/KillStatistics/KillStatisticsTotalsView.swift
+++ b/Tibia More/Features/Utils/KillStatistics/KillStatisticsTotalsView.swift
@@ -1,0 +1,24 @@
+//
+//  KillStatisticsTotalsView.swift
+//  Tibia More
+//
+//  Created by Adolpho Francisco Zimmermann Piazza on 20/01/24.
+//
+
+import SwiftUI
+
+struct KillStatisticsTotalsView: View {
+    
+    let model: KillStatisticsDataModel
+    
+    var body: some View {
+        LabeledContent("Last day killed by players", value: String(model.lastDayKilled ))
+        LabeledContent("Last day players died", value: String(model.lastDayPlayersKilled ))
+        LabeledContent("Last week killed by players", value: String(model.lastWeekKilled ))
+        LabeledContent("Last week players died", value: String(model.lastWeekPlayersKilled ))
+    }
+}
+
+#Preview {
+    KillStatisticsTotalsView(model: KillStatisticsDataModel(lastDayKilled: 3213, lastDayPlayersKilled: 31, lastWeekKilled: 42323521, lastWeekPlayersKilled: 3, race: "rotworm"))
+}

--- a/Tibia More/Features/Utils/KillStatistics/KillStatisticsView.swift
+++ b/Tibia More/Features/Utils/KillStatistics/KillStatisticsView.swift
@@ -9,12 +9,73 @@ import SwiftUI
 
 struct KillStatisticsView: View {
     
+    @State private var viewModel = KillStatisticsViewModel()
+    @State private var searchedText: String = ""
+    
+    private var filteredCreatures: [KillStatisticsDataModel] {
+        if searchedText.isEmpty {
+            return viewModel.killStatistics?.entries ?? []
+        }
+        
+        return viewModel.killStatistics?.entries.filter({ entry in
+            guard let race = entry.race else { return false }
+            return race.contains(searchedText.lowercased())
+        }) ?? []
+    }
+    
     var body: some View {
-        Text("Hello, Kill Statitics")
+        Form {
+            if searchedText.isEmpty {
+                Picker("World", selection: $viewModel.selectedWorld) {
+                    ForEach(viewModel.worlds, id: \.self) { world in
+                        Text(world)
+                    }
+                }
+                .pickerStyle(.navigationLink)
+                
+                Section("Totals") {
+                    if let totals = viewModel.killStatistics?.total {
+                        KillStatisticsTotalsView(model: totals)
+                    }
+                }
+            }
+            
+            Section("Creatures") {
+                List(filteredCreatures, id: \.self) { entry in
+                    VStack(alignment: .leading) {
+                        Text(entry.race?.capitalized ?? "")
+                            .font(.title)
+                        
+                        KillStatisticsTotalsView(model: entry)
+                    }
+                }
+            }
+        }
+        .fontDesign(.serif)
+        .opacity(viewModel.opacity)
+        .navigationTitle(viewModel.viewTitle)
+        .searchable(text: $searchedText)
+        .onChange(of: viewModel.selectedWorld, { _, _ in
+            Task {
+                await self.viewModel.fetchKillStatistics()
+            }
+        })
+        .overlay {
+            if viewModel.isLoading {
+                ProgressView()
+            }
+            
+            if viewModel.hasError && !viewModel.isLoading {
+                ContentUnavailableView("Sorry, we got an error",
+                                       systemImage: .SFImages.networkSlash)
+            }
+        }
     }
     
 }
 
 #Preview {
-    KillStatisticsView()
+    NavigationStack {
+        KillStatisticsView()
+    }
 }

--- a/Tibia More/Features/Utils/KillStatistics/KillStatisticsViewModel.swift
+++ b/Tibia More/Features/Utils/KillStatistics/KillStatisticsViewModel.swift
@@ -1,0 +1,79 @@
+//
+//  KillStatisticsViewModel.swift
+//  Tibia More
+//
+//  Created by Adolpho Francisco Zimmermann Piazza on 20/01/24.
+//
+
+import Foundation
+
+@Observable
+final class KillStatisticsViewModel {
+    
+    let viewTitle: String = "Kill Statistics"
+    var isLoading: Bool = false
+    var hasError: Bool = false
+    
+    var worlds: [String] = ["Belobra"]
+    var selectedWorld: String = "Belobra"
+    
+    var killStatistics: KillStatisticsInfoModel?
+    
+    var opacity: Double {
+        if isLoading {
+            return 0
+        }
+        
+        if !isLoading, killStatistics == nil {
+            return 0
+        }
+        
+        if !isLoading, hasError {
+            return 0
+        }
+        
+        return 1
+    }
+    
+    init() {
+        Task {
+            await self.fetchWorlds()
+            await self.fetchKillStatistics()
+        }
+    }
+    
+    @MainActor private func fetchWorlds() async {
+        defer {
+            self.isLoading = false
+        }
+        
+        self.isLoading = true
+        
+        do {
+            let result = try await WorldsService.shared.fetch()
+            self.worlds = result.regularWorlds.map({ $0.name })
+            self.hasError = false
+        } catch {
+            print("Some error occured on fetching worlds on KillStatisticsViewModel: \(error)")
+            self.hasError = true
+        }
+    }
+    
+    @MainActor func fetchKillStatistics() async {
+        defer {
+            self.isLoading = false
+        }
+        
+        self.isLoading = true
+        
+        do {
+            let result = try await UtilsService.shared.fetchKillStatistics(world: self.selectedWorld)
+            self.killStatistics = result
+            self.hasError = false
+        } catch {
+            print("Some error occured on fetching worlds on KillStatisticsViewModel: \(error)")
+            self.hasError = true
+        }
+    }
+    
+}

--- a/Tibia More/Features/Utils/UtilsListView.swift
+++ b/Tibia More/Features/Utils/UtilsListView.swift
@@ -37,7 +37,7 @@ struct UtilsListView: View {
                     case .highscores:
                         HighscoresView()
                     case .killStatistics:
-                        Text("Kill Statistics")
+                        KillStatisticsView()
                     case .fansites:
                         Text("Fansites")
                     case .guilds:

--- a/Tibia More/Networking/Utils/Models/KillStatisticsModel.swift
+++ b/Tibia More/Networking/Utils/Models/KillStatisticsModel.swift
@@ -7,16 +7,16 @@
 
 import Foundation
 
-struct KillStatisticsModel: Decodable {
+struct KillStatisticsModel: Decodable, Hashable {
     let killstatistics: KillStatisticsInfoModel
 }
 
-struct KillStatisticsInfoModel: Decodable {
+struct KillStatisticsInfoModel: Decodable, Hashable {
     let entries: [KillStatisticsDataModel]
     let total: KillStatisticsDataModel
 }
 
-struct KillStatisticsDataModel: Decodable {
+struct KillStatisticsDataModel: Decodable, Hashable {
     let lastDayKilled: Int
     let lastDayPlayersKilled: Int
     let lastWeekKilled: Int


### PR DESCRIPTION
Kill Statistics view was implemented:

<img src="https://github.com/adolphopiazza/tibiamore-ios/assets/13540565/d45a9708-9cbe-40ff-9c22-b25a69a250de" width=320 height=700>

The default world is "Belobra", but user can change it on the filter.

<img src="https://github.com/adolphopiazza/tibiamore-ios/assets/13540565/59060639-937a-44a0-b97d-302b41fd64b3" width=320 height=700>

User can also search for a specific creature.

<img src="https://github.com/adolphopiazza/tibiamore-ios/assets/13540565/c650173f-ea8b-4e73-bd94-fd8c91db716c" width=320 height=700>
