### PR TITLE
feat: implemented fansites view and fansites details view

### DIFF
--- a/Tibia More.xcodeproj/project.pbxproj
+++ b/Tibia More.xcodeproj/project.pbxproj
@@ -24,6 +24,9 @@
 		3808B1F42B5C845C003E4AB8 /* KillStatisticsTotalsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3808B1F32B5C845C003E4AB8 /* KillStatisticsTotalsView.swift */; };
 		3808B1F62B5C8CF0003E4AB8 /* FansitesModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3808B1F52B5C8CF0003E4AB8 /* FansitesModel.swift */; };
 		3808B1F92B5C8E6F003E4AB8 /* FansitesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3808B1F82B5C8E6F003E4AB8 /* FansitesView.swift */; };
+		3808B1FB2B5C8F9A003E4AB8 /* FansitesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3808B1FA2B5C8F9A003E4AB8 /* FansitesViewModel.swift */; };
+		3808B1FD2B5C9254003E4AB8 /* FansiteRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3808B1FC2B5C9254003E4AB8 /* FansiteRowView.swift */; };
+		3808B2002B5C9415003E4AB8 /* FansitesDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3808B1FF2B5C9415003E4AB8 /* FansitesDetailView.swift */; };
 		3823D5EB2B5227B0000677CB /* WorldsDetailsViewRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3823D5EA2B5227B0000677CB /* WorldsDetailsViewRow.swift */; };
 		382A29C22B1EA97500961FE2 /* Tibia_MoreApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 382A29C12B1EA97500961FE2 /* Tibia_MoreApp.swift */; };
 		382A29C42B1EA97500961FE2 /* TabBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 382A29C32B1EA97500961FE2 /* TabBarView.swift */; };
@@ -117,6 +120,9 @@
 		3808B1F32B5C845C003E4AB8 /* KillStatisticsTotalsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KillStatisticsTotalsView.swift; sourceTree = "<group>"; };
 		3808B1F52B5C8CF0003E4AB8 /* FansitesModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FansitesModel.swift; sourceTree = "<group>"; };
 		3808B1F82B5C8E6F003E4AB8 /* FansitesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FansitesView.swift; sourceTree = "<group>"; };
+		3808B1FA2B5C8F9A003E4AB8 /* FansitesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FansitesViewModel.swift; sourceTree = "<group>"; };
+		3808B1FC2B5C9254003E4AB8 /* FansiteRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FansiteRowView.swift; sourceTree = "<group>"; };
+		3808B1FF2B5C9415003E4AB8 /* FansitesDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FansitesDetailView.swift; sourceTree = "<group>"; };
 		3823D5EA2B5227B0000677CB /* WorldsDetailsViewRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldsDetailsViewRow.swift; sourceTree = "<group>"; };
 		382A29BE2B1EA97500961FE2 /* Tibia More.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Tibia More.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		382A29C12B1EA97500961FE2 /* Tibia_MoreApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tibia_MoreApp.swift; sourceTree = "<group>"; };
@@ -257,9 +263,20 @@
 		3808B1F72B5C8E64003E4AB8 /* Fansites */ = {
 			isa = PBXGroup;
 			children = (
+				3808B1FE2B5C93C9003E4AB8 /* Details */,
 				3808B1F82B5C8E6F003E4AB8 /* FansitesView.swift */,
+				3808B1FA2B5C8F9A003E4AB8 /* FansitesViewModel.swift */,
+				3808B1FC2B5C9254003E4AB8 /* FansiteRowView.swift */,
 			);
 			path = Fansites;
+			sourceTree = "<group>";
+		};
+		3808B1FE2B5C93C9003E4AB8 /* Details */ = {
+			isa = PBXGroup;
+			children = (
+				3808B1FF2B5C9415003E4AB8 /* FansitesDetailView.swift */,
+			);
+			path = Details;
 			sourceTree = "<group>";
 		};
 		382A29B52B1EA97500961FE2 = {
@@ -736,6 +753,7 @@
 				387E5A112B5C4BBF009CA577 /* HighscoresViewModel.swift in Sources */,
 				38B1E47A2B499C8900A18AB5 /* WorldsModel.swift in Sources */,
 				387E5A0C2B5C0CE5009CA577 /* HighscoresModel.swift in Sources */,
+				3808B1FB2B5C8F9A003E4AB8 /* FansitesViewModel.swift in Sources */,
 				38D6708F2B52E8840043A093 /* UtilsListView.swift in Sources */,
 				38A3EDF82B2F2DE2003C7BDA /* CharactersSearchViewModel.swift in Sources */,
 				387E5A082B5B4AC9009CA577 /* BoostedBossViewModel.swift in Sources */,
@@ -747,6 +765,7 @@
 				382A29F12B1EACFB00961FE2 /* NewsListView.swift in Sources */,
 				38084D592B543F04003FCD1B /* CreaturesViewModel.swift in Sources */,
 				38A28A822B27C2D800C707F7 /* NetworkErrors.swift in Sources */,
+				3808B2002B5C9415003E4AB8 /* FansitesDetailView.swift in Sources */,
 				3838176D2B4AEAE2000E13D7 /* WorldsListViewRow.swift in Sources */,
 				382A29F32B1EAD1C00961FE2 /* CharactersListView.swift in Sources */,
 				385D6EAE2B4AF2D600839091 /* WorldsDetailsView.swift in Sources */,
@@ -766,6 +785,7 @@
 				38A28AA72B2B7AED00C707F7 /* SafariView.swift in Sources */,
 				38AC7CEA2B24BD7000B6DF29 /* NewsListRowView.swift in Sources */,
 				38084D492B5386B6003FCD1B /* UtilsListRowView.swift in Sources */,
+				3808B1FD2B5C9254003E4AB8 /* FansiteRowView.swift in Sources */,
 				3872B02B2B5608D700725178 /* CreaturesRowView.swift in Sources */,
 				387E5A062B5B4ABC009CA577 /* BoostedBossView.swift in Sources */,
 				38C09ADF2B48A86B006B6B34 /* CharacterSearchDetailsViewModel.swift in Sources */,

--- a/Tibia More/Common/NavigationRoutes.swift
+++ b/Tibia More/Common/NavigationRoutes.swift
@@ -31,6 +31,11 @@ enum NavigationRoutes {
         enum Creatures: Hashable {
             case details(of: String)
         }
+        
+        enum Fansites: Hashable {
+            case details(of: FansiteModel)
+            case browser(with: String)
+        }
     }
     
 }

--- a/Tibia More/Features/News/Browser/BrowserView.swift
+++ b/Tibia More/Features/News/Browser/BrowserView.swift
@@ -11,15 +11,19 @@ struct BrowserView: View {
     
     @Binding var navigationPath: NavigationPath
     var url: String
+    var fromNews: Bool = true
     
     var body: some View {
         SafariView(url: URL(string: url) ?? .tibiaURL)
+            .navigationBarTitleDisplayMode(.inline)
             .ignoresSafeArea(edges: .bottom)
             .toolbar(.hidden, for: .tabBar)
             .toolbar {
-                ToolbarItem(placement: .topBarTrailing) {
-                    Button("Back to all news") {
-                        self.navigationPath.removeLast(self.navigationPath.count)
+                if fromNews {
+                    ToolbarItem(placement: .topBarTrailing) {
+                        Button("Back to all news") {
+                            self.navigationPath.removeLast(self.navigationPath.count)
+                        }
                     }
                 }
             }

--- a/Tibia More/Features/Utils/Fansites/Details/FansitesDetailView.swift
+++ b/Tibia More/Features/Utils/Fansites/Details/FansitesDetailView.swift
@@ -1,0 +1,121 @@
+//
+//  FansitesDetailView.swift
+//  Tibia More
+//
+//  Created by Adolpho Francisco Zimmermann Piazza on 20/01/24.
+//
+
+import SwiftUI
+
+struct FansitesDetailView: View {
+    
+    @Binding var navigationPath: NavigationPath
+    
+    let model: FansiteModel
+    
+    var body: some View {
+        Form {
+            headerView
+            
+            aboutView
+            
+            contentTypeView
+            
+            socialsView
+        }
+        .fontDesign(.serif)
+        .navigationTitle(model.name)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button("Visit this website") {
+                    self.navigationPath.append(NavigationRoutes.Utils.Fansites.browser(with: model.homepage))
+                }
+            }
+        }
+    }
+    
+    private var headerView: some View {
+        VStack(alignment: .center) {
+            HStack {
+                Spacer()
+                
+                AsyncImage(url: URL(string: model.logoUrl)) { image in
+                    image
+                } placeholder: {
+                    ProgressView()
+                }
+                
+                
+                Spacer()
+            }
+            
+            Text(model.name)
+                .font(.title)
+                .padding(.top, 16)
+        }
+    }
+    
+    private var aboutView: some View {
+        Section("About") {
+            LabeledContent("Contact", value: model.contact)
+            CharacterSearchDetailsViewRow(title: "Specials", value: model.specials.joined(separator: "\n"), orientation: .vertical)
+            CharacterSearchDetailsViewRow(title: "Languages", value: model.languages.joined(separator: ", "))
+            
+            if model.fansiteItem {
+                LabeledContent("Fansite Item") {
+                    AsyncImage(url: URL(string: model.fansiteItemUrl)) { image in
+                        image
+                    } placeholder: {
+                        ProgressView()
+                    }
+                    
+                }
+            }
+        }
+    }
+    
+    private var contentTypeView: some View {
+        Section("Content Type") {
+            LabeledContent("Statistics", value: model.contentType.statistics ? "✅" : "🚫")
+            LabeledContent("Texts", value: model.contentType.texts ? "✅" : "🚫")
+            LabeledContent("Tools", value: model.contentType.tools ? "✅" : "🚫")
+            LabeledContent("Wiki", value: model.contentType.wiki ? "✅" : "🚫")
+        }
+    }
+    
+    private var socialsView: some View {
+        Section("Socials") {
+            LabeledContent("Discord", value: model.socialMedia.discord ? "✅" : "🚫")
+            LabeledContent("Facebook", value: model.socialMedia.facebook ? "✅" : "🚫")
+            LabeledContent("Instagram", value: model.socialMedia.instagram ? "✅" : "🚫")
+            LabeledContent("Reddit", value: model.socialMedia.reddit ? "✅" : "🚫")
+            LabeledContent("Twitch", value: model.socialMedia.twitch ? "✅" : "🚫")
+            LabeledContent("X", value: model.socialMedia.twitter ? "✅" : "🚫")
+            LabeledContent("Youtube", value: model.socialMedia.youtube ? "✅" : "🚫")
+        }
+    }
+    
+}
+
+#Preview {
+    FansitesDetailView(navigationPath: Binding.constant(NavigationPath()),
+                       model: FansiteModel(contact: "Bomdrax",
+                                           contentType: FansiteContentModel(statistics: false,
+                                                                            texts: true,
+                                                                            tools: false,
+                                                                            wiki: false),
+                                           fansiteItem: true,
+                                           fansiteItemUrl: "https://static.tibia.com/images/community/fansiteitems/BomDiaTibia.com.gif",
+                                           homepage: "https://www.bomdiatibia.com/",
+                                           languages: ["pt"],
+                                           logoUrl: "https://static.tibia.com/images/community/fansitelogos/BomDiaTibia.com.gif",
+                                           name: "BomDiaTibia.com",
+                                           socialMedia: FansiteSocialModel(discord: true,
+                                                                           facebook: true,
+                                                                           instagram: true,
+                                                                           reddit: false,
+                                                                           twitch: false,
+                                                                           twitter: false,
+                                                                           youtube: true),
+                                           specials: ["Podcasts. Also on Spotify.", "Entertainment through contests and events."]))
+}

--- a/Tibia More/Features/Utils/Fansites/FansiteRowView.swift
+++ b/Tibia More/Features/Utils/Fansites/FansiteRowView.swift
@@ -1,0 +1,55 @@
+//
+//  FansiteRowView.swift
+//  Tibia More
+//
+//  Created by Adolpho Francisco Zimmermann Piazza on 20/01/24.
+//
+
+import SwiftUI
+
+struct FansiteRowView: View {
+    
+    let model: FansiteModel
+    
+    var body: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 16) {
+                AsyncImage(url: URL(string: model.logoUrl)) { image in
+                    image
+                } placeholder: {
+                    ProgressView()
+                }
+                
+                Text(model.name)
+                    .font(.title3)
+            }
+            
+            Spacer()
+            
+            Image(systemName: .SFImages.chevronRight)
+        }
+    }
+    
+}
+
+#Preview {
+    FansiteRowView(model: FansiteModel(contact: "",
+                                       contentType: FansiteContentModel(statistics: false, 
+                                                                        texts: false,
+                                                                        tools: false,
+                                                                        wiki: false),
+                                       fansiteItem: false,
+                                       fansiteItemUrl: "",
+                                       homepage: "",
+                                       languages: [],
+                                       logoUrl: "",
+                                       name: "",
+                                       socialMedia: FansiteSocialModel(discord: false, 
+                                                                       facebook: false,
+                                                                       instagram: false,
+                                                                       reddit: false,
+                                                                       twitch: false,
+                                                                       twitter: false,
+                                                                       youtube: false),
+                                       specials: []))
+}

--- a/Tibia More/Features/Utils/Fansites/FansitesView.swift
+++ b/Tibia More/Features/Utils/Fansites/FansitesView.swift
@@ -9,20 +9,50 @@ import SwiftUI
 
 struct FansitesView: View {
     
+    @State private var viewModel = FansitesViewModel()
+    @Binding var navigationPath: NavigationPath
+    
     var body: some View {
-        Text("Hello, Fansites!")
-            .task {
-                do {
-                    let result = try await UtilsService.shared.fetchFansites()
-                    print(result)
-                } catch {
-                    print("error")
+        Form {
+            Section("Promoted") {
+                List(viewModel.fansites?.promoted ?? [], id: \.name) { promotedFansite in
+                    FansiteRowView(model: promotedFansite)
+                        .contentShape(.rect)
+                        .onTapGesture {
+                            self.navigationPath.append(NavigationRoutes.Utils.Fansites.details(of: promotedFansite))
+                        }
                 }
             }
+            
+            Section("Supported") {
+                List(viewModel.fansites?.supported ?? [], id: \.name) { supportedFansite in
+                    FansiteRowView(model: supportedFansite)
+                        .contentShape(.rect)
+                        .onTapGesture {
+                            self.navigationPath.append(NavigationRoutes.Utils.Fansites.details(of: supportedFansite))
+                        }
+                }
+            }
+        }
+        .fontDesign(.serif)
+        .opacity(viewModel.opacity)
+        .navigationTitle(viewModel.viewTitle)
+        .overlay {
+            if viewModel.isLoading {
+                ProgressView()
+            }
+            
+            if viewModel.hasError && !viewModel.isLoading {
+                ContentUnavailableView("Sorry, we got an error",
+                                       systemImage: .SFImages.networkSlash)
+            }
+        }
     }
     
 }
 
 #Preview {
-    FansitesView()
+    NavigationStack {
+        FansitesView(navigationPath: Binding.constant(NavigationPath()))
+    }
 }

--- a/Tibia More/Features/Utils/Fansites/FansitesViewModel.swift
+++ b/Tibia More/Features/Utils/Fansites/FansitesViewModel.swift
@@ -1,0 +1,56 @@
+//
+//  FansitesViewModel.swift
+//  Tibia More
+//
+//  Created by Adolpho Francisco Zimmermann Piazza on 20/01/24.
+//
+
+import Foundation
+
+@Observable
+final class FansitesViewModel {
+    
+    let viewTitle: String = "Fansites"
+    var isLoading: Bool = false
+    var hasError: Bool = false
+    var fansites: FansitesInfoModel?
+    
+    var opacity: Double {
+        if isLoading {
+            return 0
+        }
+        
+        if !isLoading && fansites == nil {
+            return 0
+        }
+        
+        if !isLoading && hasError {
+            return 0
+        }
+        
+        return 1
+    }
+    
+    init() {
+        Task {
+            await self.fetch()
+        }
+    }
+    
+    @MainActor private func fetch() async {
+        defer {
+            self.isLoading = false
+        }
+        
+        self.isLoading = true
+        
+        do {
+            let result = try await UtilsService.shared.fetchFansites()
+            self.fansites = result
+            self.hasError = false
+        } catch {
+            print("Some error occured on FansitesViewModel: \(error)")
+            self.hasError = true
+        }
+    }
+}

--- a/Tibia More/Features/Utils/UtilsListView.swift
+++ b/Tibia More/Features/Utils/UtilsListView.swift
@@ -39,7 +39,7 @@ struct UtilsListView: View {
                     case .killStatistics:
                         KillStatisticsView()
                     case .fansites:
-                        Text("Fansites")
+                        FansitesView(navigationPath: $navigationPath)
                     case .guilds:
                         Text("Guilds")
                     }
@@ -49,6 +49,14 @@ struct UtilsListView: View {
                 switch route {
                 case .details(let race):
                     CreaturesDetailView(viewModel: CreaturesDetailViewModel(creatureRace: race))
+                }
+            }
+            .navigationDestination(for: NavigationRoutes.Utils.Fansites.self) { route in
+                switch route {
+                case .details(let model):
+                    FansitesDetailView(navigationPath: $navigationPath, model: model)
+                case .browser(let url):
+                    BrowserView(navigationPath: $navigationPath, url: url, fromNews: false)
                 }
             }
         }

--- a/Tibia More/Networking/Utils/Models/FansitesModel.swift
+++ b/Tibia More/Networking/Utils/Models/FansitesModel.swift
@@ -16,7 +16,7 @@ struct FansitesInfoModel: Decodable {
     let supported: [FansiteModel]
 }
 
-struct FansiteModel: Decodable {
+struct FansiteModel: Decodable, Hashable, Equatable {
     let contact: String
     let contentType: FansiteContentModel
     let fansiteItem: Bool
@@ -29,14 +29,14 @@ struct FansiteModel: Decodable {
     let specials: [String]
 }
 
-struct FansiteContentModel: Decodable {
+struct FansiteContentModel: Decodable, Hashable, Equatable {
     let statistics: Bool
     let texts: Bool
     let tools: Bool
     let wiki: Bool
 }
 
-struct FansiteSocialModel: Decodable {
+struct FansiteSocialModel: Decodable, Hashable, Equatable {
     let discord: Bool
     let facebook: Bool
     let instagram: Bool


### PR DESCRIPTION
The Fansites view was implemented:

<img src="https://github.com/adolphopiazza/tibiamore-ios/assets/13540565/9e8a3ca5-da11-43b6-9245-00f873e22073" width=320 height=700>

We can tap one of them to see the details:

<img src="https://github.com/adolphopiazza/tibiamore-ios/assets/13540565/dc8f17c3-34d8-44c8-b2c6-62584f69cdb2" width=320 height=700>

And we can tap the right top button to visit the homepage:

<img src="https://github.com/adolphopiazza/tibiamore-ios/assets/13540565/d7b1b2e0-1511-44bb-8c48-fa28432ba404" width=320 height=700>
