### PR TITLE
WebKit and Liquid Glass

### DIFF
--- a/Tibia More.xcodeproj/project.pbxproj
+++ b/Tibia More.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		382A2A042B1EBC8A00961FE2 /* URLConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 382A2A032B1EBC8A00961FE2 /* URLConstants.swift */; };
 		3838176B2B49A660000E13D7 /* WorldsListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3838176A2B49A660000E13D7 /* WorldsListViewModel.swift */; };
 		3838176D2B4AEAE2000E13D7 /* WorldsListViewRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3838176C2B4AEAE2000E13D7 /* WorldsListViewRow.swift */; };
+		384BF34D2E79E71900B82CB4 /* BrowserWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 384BF34C2E79E71900B82CB4 /* BrowserWebView.swift */; };
 		385D6EAE2B4AF2D600839091 /* WorldsDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 385D6EAD2B4AF2D600839091 /* WorldsDetailsView.swift */; };
 		385D6EB02B4AF2E800839091 /* WorldsDetailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 385D6EAF2B4AF2E800839091 /* WorldsDetailsViewModel.swift */; };
 		3872B02B2B5608D700725178 /* CreaturesRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3872B02A2B5608D700725178 /* CreaturesRowView.swift */; };
@@ -178,6 +179,7 @@
 		382A2A032B1EBC8A00961FE2 /* URLConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLConstants.swift; sourceTree = "<group>"; };
 		3838176A2B49A660000E13D7 /* WorldsListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldsListViewModel.swift; sourceTree = "<group>"; };
 		3838176C2B4AEAE2000E13D7 /* WorldsListViewRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldsListViewRow.swift; sourceTree = "<group>"; };
+		384BF34C2E79E71900B82CB4 /* BrowserWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserWebView.swift; sourceTree = "<group>"; };
 		385D6EAD2B4AF2D600839091 /* WorldsDetailsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldsDetailsView.swift; sourceTree = "<group>"; };
 		385D6EAF2B4AF2E800839091 /* WorldsDetailsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldsDetailsViewModel.swift; sourceTree = "<group>"; };
 		3872B02A2B5608D700725178 /* CreaturesRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreaturesRowView.swift; sourceTree = "<group>"; };
@@ -625,6 +627,7 @@
 			isa = PBXGroup;
 			children = (
 				38A28AA92B2B7CD500C707F7 /* BrowserView.swift */,
+				384BF34C2E79E71900B82CB4 /* BrowserWebView.swift */,
 			);
 			path = Browser;
 			sourceTree = "<group>";
@@ -957,6 +960,7 @@
 				38A5582C2B82587900F31857 /* SpellsView.swift in Sources */,
 				3808B1FD2B5C9254003E4AB8 /* FansiteRowView.swift in Sources */,
 				3872B02B2B5608D700725178 /* CreaturesRowView.swift in Sources */,
+				384BF34D2E79E71900B82CB4 /* BrowserWebView.swift in Sources */,
 				387E5A062B5B4ABC009CA577 /* BoostedBossView.swift in Sources */,
 				38C09ADF2B48A86B006B6B34 /* CharacterSearchDetailsViewModel.swift in Sources */,
 				3808B20A2B5DB596003E4AB8 /* GuildDetailsView.swift in Sources */,
@@ -1152,12 +1156,11 @@
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.2;
+				MARKETING_VERSION = 1.1.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.adolphopiazza.Tibia-More";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -1183,12 +1186,11 @@
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.2;
+				MARKETING_VERSION = 1.1.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.adolphopiazza.Tibia-More";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/Tibia More/Common/Localizable.xcstrings
+++ b/Tibia More/Common/Localizable.xcstrings
@@ -313,6 +313,23 @@
         }
       }
     },
+    "Character.Loading" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Loading characters..."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Carregando personagens..."
+          }
+        }
+      }
+    },
     "Character.Remove" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Tibia More/Common/NavigationRoutes.swift
+++ b/Tibia More/Common/NavigationRoutes.swift
@@ -11,7 +11,7 @@ enum NavigationRoutes {
     
     enum News: Hashable {
         case details(of: NewsInformationModel)
-        case browser(with: String)
+        case browser(with: String, title: String)
     }
     
     enum Characters: Hashable {

--- a/Tibia More/Features/Characters/CharactersListView.swift
+++ b/Tibia More/Features/Characters/CharactersListView.swift
@@ -23,6 +23,7 @@ struct CharactersListView: View {
                     }
             }
             .disabled(viewModel.isLoading)
+            .opacity(viewModel.isLoading ? 0.5 : 1)
             .navigationTitle(viewModel.viewTitle.localized)
             .task {
                 await viewModel.checkUserDefaults()
@@ -46,7 +47,9 @@ struct CharactersListView: View {
                 }
                 
                 if viewModel.isLoading {
-                    ProgressView()
+                    ProgressView {
+                        Text("Character.Loading")
+                    }
                 }
             }
             .toolbar {

--- a/Tibia More/Features/News/Browser/BrowserWebView.swift
+++ b/Tibia More/Features/News/Browser/BrowserWebView.swift
@@ -1,0 +1,48 @@
+//
+//  BrowserWebView.swift
+//  Tibia More
+//
+//  Created by Adolpho Francisco Zimmermann Piazza on 16/09/25.
+//
+
+import SwiftUI
+import WebKit
+
+@available(iOS 26.0, *)
+struct BrowserWebView: View {
+    
+    @State private var webPage = WebPage()
+    @Binding var navigationPath: NavigationPath
+    
+    var url: String
+    var newsTitle: String
+    
+    var body: some View {
+        WebView(webPage)
+            .task {
+                webPage.load(URL(string: url))
+            }
+            .toolbar(.hidden, for: .tabBar)
+            .navigationTitle(newsTitle)
+            .navigationBarTitleDisplayMode(.inline)
+            .clipped()
+            .scrollIndicators(.hidden)
+            .ignoresSafeArea(.all, edges: .bottom)
+            .overlay {
+                if webPage.isLoading {
+                    ProgressView()
+                }
+            }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        if #available(iOS 26.0, *) {
+            BrowserWebView(navigationPath: .constant(NavigationPath()), url: "https://www.tibia.com/news/?subtopic=newsarchive&id=8416",
+                           newsTitle: "Double Exp")
+        } else {
+            BrowserView(navigationPath: .constant(NavigationPath()), url: "https://www.tibia.com/news/?subtopic=newsarchive&id=8416")
+        }
+    }
+}

--- a/Tibia More/Features/News/NewsListView.swift
+++ b/Tibia More/Features/News/NewsListView.swift
@@ -37,7 +37,7 @@ struct NewsListView: View {
                         NewsListRowView(viewModel: .init(news))
                             .contentShape(Rectangle())
                             .onTapGesture {
-                                navigationPath.append(NavigationRoutes.News.browser(with: news.url))
+                                navigationPath.append(NavigationRoutes.News.browser(with: news.url, title: news.news))
                             }
                     }
                 }
@@ -63,8 +63,12 @@ struct NewsListView: View {
                 switch route {
                 case .details(let news):
                     NewsListTickerDetailView(viewModel: .init(newsID: news.id), navigationPath: $navigationPath)
-                case .browser(let url):
-                    BrowserView(navigationPath: $navigationPath, url: url)
+                case .browser(let url, let title):
+                    if #available(iOS 26.0, *) {
+                        BrowserWebView(navigationPath: $navigationPath, url: url, newsTitle: title)
+                    } else {
+                        BrowserView(navigationPath: $navigationPath, url: url)
+                    }
                 }
             }
         }

--- a/Tibia More/Features/News/Ticker/Details/NewsListTickerDetailView.swift
+++ b/Tibia More/Features/News/Ticker/Details/NewsListTickerDetailView.swift
@@ -22,7 +22,7 @@ struct NewsListTickerDetailView: View {
                 }
                 
                 Button(action: {
-                    let route = NavigationRoutes.News.browser(with: viewModel.detailedNews.url)
+                    let route = NavigationRoutes.News.browser(with: viewModel.detailedNews.url, title: viewModel.detailedNews.title ?? "News Ticker")
                     self.navigationPath.append(route)
                 }, label: {
                     Text("News.Row.TibiaWebsite")


### PR DESCRIPTION
For iOS 26 users we now use the new WebKit API, app is now built with Xcode 26 to support Liquid Glass and added a label when loading characters.